### PR TITLE
fix: include context

### DIFF
--- a/lib/module.plugin.js
+++ b/lib/module.plugin.js
@@ -1,7 +1,7 @@
 export default (context) => {
   if (process.browser) {
     setTimeout(() => {
-      context.store.dispatch('nuxtClientInit')
+      context.store.dispatch('nuxtClientInit', context)
     }, 0)
   }
 }


### PR DESCRIPTION
```
export const actions = {
  nuxtClientInit({ commit }, context) {
    // context -> undefined
  }
}
```

Context value on nuxtClientInit is undefined.
This PR will set context correctly.