### PR TITLE
Hotfix: Change arrow function to prevent losing scope

### DIFF
--- a/lib/module.plugin.js
+++ b/lib/module.plugin.js
@@ -1,4 +1,4 @@
-export default async (context) => {
+export default async function (context) {
   if (process.browser) {
     await context.store.dispatch('nuxtClientInit', context)
   }


### PR DESCRIPTION
# Hotfix: Change arrow function to prevent losing scope

## Issue
When using arrow functions `this` will come from the outer scope where $axios for example, doesn't exist. 
The result of this is that `this.$axios` inside your Vuex action will be undefined.

## Solution
Change the arrow function to a normal function
