### PR TITLE
Changed plugin start on a client

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -7,7 +7,7 @@ const defaults = {
 
 module.exports = function clientInitModule() {
   this.addPlugin(
-    path.resolve(__dirname, 'module.plugin.js')
+    path.resolve(__dirname, 'module.plugin.client.js')
   )
 }
 

--- a/lib/module.plugin.client.js
+++ b/lib/module.plugin.client.js
@@ -1,0 +1,3 @@
+export default async function (context) {
+  await context.store.dispatch('nuxtClientInit', context)
+}

--- a/lib/module.plugin.js
+++ b/lib/module.plugin.js
@@ -1,5 +1,0 @@
-export default async function (context) {
-  if (process.browser) {
-    await context.store.dispatch('nuxtClientInit', context)
-  }
-}

--- a/test/fixture/store/index.js
+++ b/test/fixture/store/index.js
@@ -8,7 +8,7 @@ export const getters = {
 
 export const mutations = {
   dispatchAction(state) {
-    state.isDispatched = true
+    state.isDispatched = !state.isDispatched
   }
 }
 


### PR DESCRIPTION
Client side plugin start filter changed from condition to plugin naming convention mechanism
https://nuxtjs.org/docs/2.x/directory-structure/plugins/#name-conventional-plugin